### PR TITLE
fix: 残存する不要なプロジェクトを完全削除

### DIFF
--- a/js/github-api.js
+++ b/js/github-api.js
@@ -317,26 +317,8 @@ class GitHubApiClient {
     getFallbackRepositories() {
         console.warn('GitHub API: フォールバックデータを使用');
         
-        return [
-            {
-                id: 'fallback-portfolio',
-                title: 'Portfolio Website',
-                description: 'HTML、CSS、JavaScriptで構築したレスポンシブ対応のポートフォリオサイト',
-                technologies: ['HTML5', 'CSS3', 'JavaScript', 'GitHub Pages'],
-                image: null,
-                demoUrl: 'https://purplehoge.github.io/purplehoge-portfolio/',
-                sourceUrl: 'https://github.com/purplehoge/purplehoge-portfolio',
-                status: 'completed',
-                featured: true,
-                githubData: {
-                    stars: 0,
-                    language: 'HTML',
-                    updatedAt: new Date(),
-                    createdAt: new Date(),
-                    topics: ['portfolio', 'javascript', 'html', 'css']
-                }
-            }
-        ];
+        // GitHub API障害時も不要なプロジェクトは表示しない
+        return [];
     }
 
     /**

--- a/js/main.js
+++ b/js/main.js
@@ -212,8 +212,15 @@ class PortfolioApp {
             
             // GitHubデータのみを使用（フォールバックデータは統合しない）
             projectsData = githubRepos.filter(project => {
-                // デモURLまたはソースURLが存在するプロジェクトのみ表示
-                return project.demoUrl || project.sourceUrl;
+                // より厳密なフィルタリング条件
+                const hasDemo = project.demoUrl && project.demoUrl.trim() !== '';
+                const hasValidSource = project.sourceUrl && project.sourceUrl.trim() !== '';
+                const isNotReadmeOnly = !project.title.toLowerCase().includes('readme');
+                const isNotConfigOnly = !project.title.toLowerCase().includes('config');
+                const isNotPrivateProfile = project.title.toLowerCase() !== 'purplehoge';
+                
+                // デモサイトがあるか、有効なソースでかつ実用的なリポジトリ
+                return (hasDemo || hasValidSource) && isNotReadmeOnly && isNotConfigOnly && isNotPrivateProfile;
             });
             
             console.log(`プロジェクトデータ読み込み完了: ${projectsData.length}件`, projectsData);


### PR DESCRIPTION
## 概要
Projectsセクションにまだ残っている不要なプロジェクトを完全に削除しました。

## 修正内容
### Before
- GitHub APIフォールバック処理で不要な「Portfolio Website」が表示
- README専用リポジトリやプロフィール専用リポジトリが表示される可能性

### After
- より厳密なフィルタリング条件を実装
- GitHub APIフォールバックを空配列に変更
- 実用的なプロジェクトのみ表示

## フィルタリング条件
### 除外対象
- README専用リポジトリ
- 設定専用リポジトリ  
- プロフィール専用リポジトリ（purplehoge）
- デモサイトもソースコードもないリポジトリ

### 表示対象  
- デモサイト（homepage）が設定されているリポジトリ
- または有効なソースコード（html_url）があるリポジトリ
- かつ実用的なプロジェクトリポジトリ

## 影響範囲
- Projectsセクションの表示内容のみ
- より厳選されたプロジェクトのみ表示
- GitHub API障害時も不要なプロジェクトは非表示

🤖 Generated with Claude Code